### PR TITLE
Add requirements.txt for reproducability.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+mock==1.0.1
+commonmark==0.9.1
+alabaster>=0.7,<0.8,!=0.7.5
+commonmark==0.9.1
+recommonmark==0.5.0
+jinja2==3.0.3
+mkdocs==1.4.2


### PR DESCRIPTION
Without this file, RtD will not correctly reproduce the environment to build the documentation. Adding requirements.txt to pin dependencies, which seems to build the same docs as in production.