### PR TITLE
Add ReadTheDocs config file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,16 @@
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+
+mkdocs:
+  configuration: mkdocs.yml
+
+# Optionally declare the Python requirements required to build your docs
+python:
+  install:
+  - requirements: requirements.txt


### PR DESCRIPTION
Some time since the last successful compilation 8 months ago, ReadTheDocs has apparently added a requirement to have a configuration file at the root of the repo, which I missed.
Creating this config file now based on https://docs.readthedocs.io/en/stable/config-file/v2.html